### PR TITLE
fix(sdl2): apply Linux desktop scaling to window size and UI scale

### DIFF
--- a/core/app/sdl2_app_main.cpp
+++ b/core/app/sdl2_app_main.cpp
@@ -121,7 +121,13 @@ float dpiScale(SDL_Window* window) {
         }
     }
 #endif
-    return pointerScale(window);
+    const float drawableRatio = pointerScale(window);
+    if (drawableRatio > 1.0f) {
+        return drawableRatio;
+    }
+    // On Linux the drawable-to-window ratio does not reflect desktop scaling,
+    // so fall back to the display DPI reported by SDL.
+    return core::window::displayScaleEstimate(SDL_GetWindowDisplayIndex(window));
 }
 
 void attachNativeChildWindow(SDL_Window* parentWindow, SDL_Window* childWindow) {

--- a/core/window/window_backend.cpp
+++ b/core/window/window_backend.cpp
@@ -2,6 +2,7 @@
 #include "core/platform/native_bridge.h"
 
 #include <algorithm>
+#include <cmath>
 
 #if defined(EUI_WINDOW_BACKEND_SDL2)
 
@@ -201,14 +202,43 @@ void uninstallSdlImeFilter(SDL_Window* window) {
 
 } // namespace
 
+float displayScaleEstimate(int displayIndex) {
+#if defined(_WIN32) || defined(__APPLE__)
+    (void)displayIndex;
+    return 1.0f;
+#else
+    if (displayIndex < 0) {
+        displayIndex = 0;
+    }
+    float diagonalDpi = 0.0f;
+    if (SDL_GetDisplayDPI(displayIndex, &diagonalDpi, nullptr, nullptr) != 0 ||
+        diagonalDpi < 120.0f) {
+        return 1.0f;
+    }
+    return std::round((diagonalDpi / 96.0f) * 4.0f) / 4.0f;
+#endif
+}
+
 Handle createWindow(const WindowCreateRequest& request) {
     if (request.renderApi == RenderApi::OpenGL) {
         configureOpenGLWindowAttributes();
     }
 
     Uint32 flags = 0;
+    int width = request.width;
+    int height = request.height;
     if (request.highDpi) {
         flags |= SDL_WINDOW_ALLOW_HIGHDPI;
+#if !defined(_WIN32) && !defined(__APPLE__)
+        // On Linux the SDL drawable size never reflects desktop scaling, so
+        // the drawable-to-window ratio stays 1.0 and the UI would render at a
+        // physically smaller size than on other backends. Enlarge the window
+        // by the desktop scale so its buffer covers the same physical area;
+        // dpiScale() derives the matching scale from the display DPI.
+        const float displayScale = displayScaleEstimate(0);
+        width = static_cast<int>(std::lround(width * displayScale));
+        height = static_cast<int>(std::lround(height * displayScale));
+#endif
     }
     if (request.resizable) {
         flags |= SDL_WINDOW_RESIZABLE;
@@ -219,8 +249,8 @@ Handle createWindow(const WindowCreateRequest& request) {
         request.title != nullptr ? request.title : "",
         SDL_WINDOWPOS_CENTERED,
         SDL_WINDOWPOS_CENTERED,
-        request.width,
-        request.height,
+        width,
+        height,
         flags);
 #if defined(_WIN32)
     installSdlImeFilter(window);

--- a/core/window/window_backend.h
+++ b/core/window/window_backend.h
@@ -10,6 +10,12 @@ Handle createWindow(const WindowCreateRequest& request);
 void destroyWindow(Handle window);
 NativeWindowInfo nativeWindowInfo(Handle window);
 
+// SDL2 only: estimates the desktop scaling factor for a display via
+// SDL_GetDisplayDPI, quantized to 0.25 steps. Returns 1.0f when the scale
+// cannot be determined or is below 1.25x, and on platforms where SDL already
+// reports high-density drawable sizes (Windows, macOS).
+float displayScaleEstimate(int displayIndex);
+
 ContextKey currentContextKey();
 double timeSeconds();
 void postEmptyEvent();


### PR DESCRIPTION
## What

On Linux, derive the desktop scaling factor from SDL display DPI (quantized to 0.25 steps, 1.25x minimum), enlarge newly created SDL windows by that factor, and use it as the `dpiScale` fallback when the drawable-to-window size ratio is 1.0.

## Why

SDL drawables on Linux (X11 and Wayland) never reflect desktop scaling — the drawable size always equals the window size. The SDL2 backend therefore computed a `dpiScale` of 1.0 and rendered unscaled, physically smaller UI than GLFW builds on HiDPI desktops (e.g. 2x Wayland sessions). GLFW builds scale correctly because GLFW reads the desktop content scale directly; Windows was already handled via `GetDpiForWindow`; macOS reports a 2.0 drawable ratio.

## How

- Add `core::window::displayScaleEstimate()`, which quantizes `SDL_GetDisplayDPI`-derived scale to 0.25 steps and ignores values below 1.25x (avoids false positives from physical EDID-reported DPI on unscaled displays).
- In `createWindow` (Linux SDL2 only), multiply the requested window size by that estimate so the buffer covers the same physical area as other backends.
- In the SDL2 app entry point's `dpiScale()`, keep the drawable ratio as the primary source (macOS Retina) and fall back to `displayScaleEstimate()` so logical layout size, rendering scale, and pointer mapping stay consistent.

## Testing

Verified on Fedora 44 (Wayland session, 2x desktop scaling, Xft.dpi=192) with all four backend combinations (OpenGL/Vulkan × GLFW/SDL2):

- `gallery` and other examples in SDL2 builds now show the same physical window size and UI scale as GLFW builds, with native crispness (GLFW via XWayland is compositor-upscaled and slightly blurrier).
- `ctest` results unchanged on all four builds: 19/20 passing.

Note: the single failing test, `shadertoy_runtime_probe`, **already fails on the base `dev` branch** (introduced by c404bde `perf(render): cache static siblings`, fails identically on all four backend builds) and is unrelated to this change.