### PR TITLE
fix(render): skip sibling-run caching inside retained containers

### DIFF
--- a/core/runtime/runtime_render.h
+++ b/core/runtime/runtime_render.h
@@ -389,11 +389,37 @@ inline void RuntimeRenderer::renderElementChildren(
         }
     };
 
+    // When this element is itself eligible for a retained layer, caching a
+    // stable sibling run inside it would duplicate the same content into a
+    // second offscreen layer during warmup. Skip run detection in that case;
+    // runs are only useful for subtrees that cannot be cached as a unit.
+    bool parentUsesRetainedLayer = false;
+    if (!element.subtreeBlocksRetainedLayer &&
+        !element.subtreeHasDependentVisuals &&
+        !element.subtreeHasBackdropBlur &&
+        !retainedLayerRenderDisabled_ &&
+        !renderTransform.active &&
+        closeEnough(renderTransform.opacity, 1.0f)) {
+        const auto parentBounds = instances_.paintBounds.find(element.id);
+        if (parentBounds != instances_.paintBounds.end()) {
+            const Rect subtreePixels = toPixelRect(parentBounds->second.subtree, dpiScale);
+            parentUsesRetainedLayer =
+                isRetainedLayerCandidate(element,
+                                         parentBounds->second,
+                                         subtreePixels,
+                                         dirtyRect,
+                                         hasScissor,
+                                         scissorRect);
+        }
+    }
+
     std::size_t index = 0;
     while (index < children.size()) {
         std::size_t runEnd = index;
-        while (runEnd < children.size() && isRetainedSiblingCandidate(*children[runEnd])) {
-            ++runEnd;
+        if (!parentUsesRetainedLayer) {
+            while (runEnd < children.size() && isRetainedSiblingCandidate(*children[runEnd])) {
+                ++runEnd;
+            }
         }
 
         if (runEnd - index >= 2) {

--- a/tests/probes/shadertoy_runtime_probe.cpp
+++ b/tests/probes/shadertoy_runtime_probe.cpp
@@ -345,7 +345,12 @@ bool retainedLayerBlocker(core::window::Handle window) {
         runtime.render(160, 120, 1.0f, {});
         runtime.shutdown(false);
     }
-    return staticBackend.layersCreated == 1 && dynamicBackend.layersCreated == 0;
+    // Static tree: the container is cached as a single retained layer, and
+    // the stable sibling run inside it must not be cached again in a second
+    // layer. Dynamic tree: the container is blocked by the shadertoy, but the
+    // run of static sibling rects is still cached as one layer so the
+    // shadertoy's repaints do not redraw them.
+    return staticBackend.layersCreated == 1 && dynamicBackend.layersCreated == 1;
 }
 
 } // namespace


### PR DESCRIPTION
## What

Detect when an element is itself eligible for a retained layer and skip stable-sibling-run detection for its children; update `shadertoy_runtime_probe` to match the intended retained-sibling behavior.

## Why

`shadertoy_runtime_probe` (label `probe`, run in CI via xvfb) currently **fails on `dev`** after c404bde, identically across all four backend builds (OpenGL/Vulkan × GLFW/SDL2). Two issues:

1. **Double caching (bug):** a fully static container is cached twice — once as its own retained layer and again as a sibling-run layer over the exact same content. Both layers are warmed and rebuilt during startup, wasting an offscreen layer and GPU memory. Measured with the probe's recording backend: 2 layers created where 1 suffices.
2. **Stale probe expectation:** the probe still expects **zero** layers when a shadertoy blocks the container. But caching the static sibling run in that situation is the stated purpose of the retained-sibling feature — *"Overlapping static elements were redrawn for every button interaction"* (c404bde). Blocking run detection whenever the parent is blocked would defeat the feature's main use case.

**Note for review:** this PR changes the probe's expected layer count for the shadertoy-blocked tree from 0 to 1, based on the feature intent described in c404bde. If the intended behavior is actually "no retained layers at all in subtrees containing a shadertoy", the alternative fix would be gating run detection on the parent's `subtreeBlocksRetainedLayer` instead — happy to rework if so.

## How

- In `renderElementChildren`, compute the parent element's retained-layer eligibility (same checks as the per-child path: block flags, transform/opacity, geometry via `isRetainedLayerCandidate`) and bypass sibling-run detection when the parent is eligible. Runs remain active for blocked or otherwise ineligible parents (e.g. containers holding buttons or shadertoys), preserving the feature's intent.
- Update the probe to document both intended behaviors: **1 layer** for the fully static tree (container only, no nested run layer) and **1 layer** for the static run beside a shadertoy.

## Testing

Fedora 44, all four backend combinations (OpenGL/Vulkan × GLFW/SDL2): **ctest 20/20 passing** on each build (was 19/20 with `shadertoy_runtime_probe` failing before this change).