### PR TITLE
Feat/win32 live resize

### DIFF
--- a/core/app/glfw_app_main.cpp
+++ b/core/app/glfw_app_main.cpp
@@ -326,6 +326,11 @@ void renderMainFrameDuringResize(GLFWwindow* window,
     const float dpiScale = getDpiScale(window);
     const float pointerScale = getPointerScale(window);
 
+    // While resizing, the whole window is repainted every frame, so the
+    // retained render cache would be rebuilt at each intermediate size for no
+    // benefit. Render directly to the framebuffer instead, which avoids the
+    // GPU memory churn of recreating the cache texture during the drag.
+    app::detail::setDirectRender(true);
     mainWindowRuntime.updateAndRender(
         window,
         renderBackend,
@@ -334,6 +339,7 @@ void renderMainFrameDuringResize(GLFWwindow* window,
         false,  // recompose/layout only when the size actually changed
         false,  // neutralise pointer input so the drag is not treated as UI interaction
         [] {});
+    app::detail::setDirectRender(false);
     windowState.advanceFrameClock(now, false);
 }
 #endif // _WIN32

--- a/core/app/glfw_app_main.cpp
+++ b/core/app/glfw_app_main.cpp
@@ -253,6 +253,7 @@ namespace {
 struct ResizeRepaintHook {
     WNDPROC previousProc = nullptr;
     std::function<void()> repaint;
+    std::function<void()> onResizeEnd;
 };
 
 const wchar_t* const kResizeRepaintProp = L"EuiNeoResizeRepaint";
@@ -273,11 +274,15 @@ LRESULT CALLBACK resizeRepaintWndProc(HWND hwnd, UINT message, WPARAM wParam, LP
 
     if (message == WM_SIZING && hook->repaint) {
         hook->repaint();
+    } else if (message == WM_EXITSIZEMOVE && hook->onResizeEnd) {
+        hook->onResizeEnd();
     }
     return result;
 }
 
-void installResizeRepaintHook(GLFWwindow* window, std::function<void()> repaint) {
+void installResizeRepaintHook(GLFWwindow* window,
+                              std::function<void()> repaint,
+                              std::function<void()> onResizeEnd) {
     HWND hwnd = glfwGetWin32Window(window);
     if (hwnd == nullptr || resizeRepaintHook(hwnd) != nullptr) {
         return;
@@ -286,6 +291,7 @@ void installResizeRepaintHook(GLFWwindow* window, std::function<void()> repaint)
     auto* hook = new ResizeRepaintHook();
     hook->previousProc = reinterpret_cast<WNDPROC>(GetWindowLongPtrW(hwnd, GWLP_WNDPROC));
     hook->repaint = std::move(repaint);
+    hook->onResizeEnd = std::move(onResizeEnd);
     SetPropW(hwnd, kResizeRepaintProp, hook);
     SetWindowLongPtrW(hwnd, GWLP_WNDPROC, reinterpret_cast<LONG_PTR>(resizeRepaintWndProc));
 }
@@ -559,9 +565,17 @@ int main() {
     // Install after the IME filter so that when the IME filter is uninstalled
     // it restores the WndProc chain back to this hook; this hook is then
     // removed before the IME filter on shutdown, keeping the chain intact.
-    installResizeRepaintHook(window, [&] {
-        renderMainFrameDuringResize(window, windowState, *renderBackend, mainWindowRuntime);
-    });
+    installResizeRepaintHook(
+        window,
+        [&] {
+            renderMainFrameDuringResize(window, windowState, *renderBackend, mainWindowRuntime);
+        },
+        [&] {
+            // The drag reallocated the window's back buffer at every
+            // intermediate size; glFinish lets the driver actually release the
+            // retained buffers instead of keeping them pooled.
+            renderBackend->flush();
+        });
 #endif
     windowState.initializeTray();
     glfwSetWindowCloseCallback(window, [](GLFWwindow* currentWindow) {

--- a/core/app/glfw_app_main.cpp
+++ b/core/app/glfw_app_main.cpp
@@ -32,6 +32,7 @@
 #include <cstdio>
 #include <memory>
 #include <thread>
+#include <utility>
 #include <vector>
 
 struct WindowState : app::AppRunner {
@@ -236,6 +237,106 @@ void installWindowCallbacks(GLFWwindow* window, WindowState& windowState) {
         }
     });
 }
+
+#ifdef _WIN32
+namespace {
+
+// Live-resize repaint hook.
+//
+// While the user drags the resize border, Windows runs a modal loop inside
+// DefWindowProc (entered from WM_SYSCOMMAND/SC_SIZE). That loop keeps
+// dispatching messages but never returns control to the app's main loop, so
+// the regular render loop stalls until the mouse is released. To repaint
+// while the drag is in progress we subclass the window and render one frame
+// directly from WM_SIZING, which the modal loop dispatches continuously.
+// Rendering here is safe: update/render/swap never dispatch window messages.
+struct ResizeRepaintHook {
+    WNDPROC previousProc = nullptr;
+    std::function<void()> repaint;
+};
+
+const wchar_t* const kResizeRepaintProp = L"EuiNeoResizeRepaint";
+
+ResizeRepaintHook* resizeRepaintHook(HWND hwnd) {
+    return static_cast<ResizeRepaintHook*>(GetPropW(hwnd, kResizeRepaintProp));
+}
+
+LRESULT CALLBACK resizeRepaintWndProc(HWND hwnd, UINT message, WPARAM wParam, LPARAM lParam) {
+    ResizeRepaintHook* hook = resizeRepaintHook(hwnd);
+    if (hook == nullptr) {
+        return DefWindowProcW(hwnd, message, wParam, lParam);
+    }
+
+    const LRESULT result = hook->previousProc != nullptr
+        ? CallWindowProcW(hook->previousProc, hwnd, message, wParam, lParam)
+        : DefWindowProcW(hwnd, message, wParam, lParam);
+
+    if (message == WM_SIZING && hook->repaint) {
+        hook->repaint();
+    }
+    return result;
+}
+
+void installResizeRepaintHook(GLFWwindow* window, std::function<void()> repaint) {
+    HWND hwnd = glfwGetWin32Window(window);
+    if (hwnd == nullptr || resizeRepaintHook(hwnd) != nullptr) {
+        return;
+    }
+
+    auto* hook = new ResizeRepaintHook();
+    hook->previousProc = reinterpret_cast<WNDPROC>(GetWindowLongPtrW(hwnd, GWLP_WNDPROC));
+    hook->repaint = std::move(repaint);
+    SetPropW(hwnd, kResizeRepaintProp, hook);
+    SetWindowLongPtrW(hwnd, GWLP_WNDPROC, reinterpret_cast<LONG_PTR>(resizeRepaintWndProc));
+}
+
+void uninstallResizeRepaintHook(GLFWwindow* window) {
+    HWND hwnd = glfwGetWin32Window(window);
+    ResizeRepaintHook* hook = hwnd != nullptr ? resizeRepaintHook(hwnd) : nullptr;
+    if (hook == nullptr) {
+        return;
+    }
+
+    SetWindowLongPtrW(hwnd, GWLP_WNDPROC, reinterpret_cast<LONG_PTR>(hook->previousProc));
+    RemovePropW(hwnd, kResizeRepaintProp);
+    delete hook;
+}
+
+} // namespace
+
+// Renders one frame of the main window immediately, at the current committed
+// framebuffer size. Invoked from the resize hook while the Windows resize
+// modal loop is running, so it must not pump window messages or sleep.
+void renderMainFrameDuringResize(GLFWwindow* window,
+                                 WindowState& windowState,
+                                 core::render::RenderBackend& renderBackend,
+                                 app::MainWindowRuntime& mainWindowRuntime) {
+    const double now = glfwGetTime();
+    if (now < windowState.nextFrameTime) {
+        return;
+    }
+
+    int framebufferWidth = 0;
+    int framebufferHeight = 0;
+    glfwGetFramebufferSize(window, &framebufferWidth, &framebufferHeight);
+    if (framebufferWidth <= 0 || framebufferHeight <= 0) {
+        return;
+    }
+
+    const float dpiScale = getDpiScale(window);
+    const float pointerScale = getPointerScale(window);
+
+    mainWindowRuntime.updateAndRender(
+        window,
+        renderBackend,
+        {framebufferWidth, framebufferHeight, dpiScale, pointerScale},
+        windowState.consumeFrameDelta(now),
+        false,  // recompose/layout only when the size actually changed
+        false,  // neutralise pointer input so the drag is not treated as UI interaction
+        [] {});
+    windowState.advanceFrameClock(now, false);
+}
+#endif // _WIN32
 
 std::unique_ptr<ManagedWindow> createManagedWindow(const app::DslWindowRequest& request,
                                                    GLFWwindow* parentWindow,
@@ -448,6 +549,14 @@ int main() {
         return -1;
     }
     app::MainWindowRuntime mainWindowRuntime(windowState);
+#ifdef _WIN32
+    // Install after the IME filter so that when the IME filter is uninstalled
+    // it restores the WndProc chain back to this hook; this hook is then
+    // removed before the IME filter on shutdown, keeping the chain intact.
+    installResizeRepaintHook(window, [&] {
+        renderMainFrameDuringResize(window, windowState, *renderBackend, mainWindowRuntime);
+    });
+#endif
     windowState.initializeTray();
     glfwSetWindowCloseCallback(window, [](GLFWwindow* currentWindow) {
         WindowState* state = static_cast<WindowState*>(glfwGetWindowUserPointer(currentWindow));
@@ -571,6 +680,9 @@ int main() {
     }
 
     childWindows.destroyAll(destroyManagedWindow);
+#ifdef _WIN32
+    uninstallResizeRepaintHook(window);
+#endif
     core::releaseInputQueue(window);
     renderBackend->makeCurrent();
     renderBackend->releaseRenderCache();

--- a/core/dsl_runtime.h
+++ b/core/dsl_runtime.h
@@ -47,6 +47,12 @@ public:
 
     void requestFullPaint();
 
+    // When enabled, render() draws directly to the default framebuffer and
+    // skips the retained render cache. Useful when the whole window is known
+    // to be dirty every frame (e.g. while the window is being resized), which
+    // avoids churning the cache texture through many intermediate sizes.
+    void setDirectRender(bool enabled);
+
     void render(int windowWidth, int windowHeight, float dpiScale, const Color& clearColor);
 
     void render(int windowWidth, int windowHeight, float dpiScale);
@@ -269,6 +275,7 @@ private:
     std::vector<runtime::ElementSnapshot> elementStructure_;
     std::vector<runtime::LogicalDirtyRect> dirtyRects_;
     bool paintRequested_ = true;
+    bool directRender_ = false;
     bool animating_ = false;
     bool composeRequested_ = false;
     bool fullPaintRequested_ = true;

--- a/core/render/opengl/opengl_backend.cpp
+++ b/core/render/opengl/opengl_backend.cpp
@@ -273,6 +273,11 @@ void OpenGLRenderBackend::present() {
     }
 }
 
+void OpenGLRenderBackend::flush() {
+    makeCurrent();
+    glFinish();
+}
+
 bool OpenGLRenderBackend::ensureRenderCache(int width, int height) {
     flushRoundedRectBatch();
     cacheRecreated_ = false;

--- a/core/render/opengl/opengl_backend.h
+++ b/core/render/opengl/opengl_backend.h
@@ -23,6 +23,7 @@ public:
     void makeCurrent() override;
     void beginFrame(const RenderSurface& surface) override;
     void present() override;
+    void flush() override;
     bool ensureRenderCache(int width, int height) override;
     bool renderCacheWasRecreated() const override;
     void releaseRenderCache() override;

--- a/core/render/render_backend.h
+++ b/core/render/render_backend.h
@@ -180,6 +180,10 @@ public:
     virtual void makeCurrent() = 0;
     virtual void beginFrame(const RenderSurface& surface) = 0;
     virtual void present() = 0;
+    // Blocks until all pending GPU work has completed. Used after a resize drag
+    // to let the driver release back buffers that were reallocated at each
+    // intermediate size.
+    virtual void flush() {}
     virtual bool ensureRenderCache(int width, int height) = 0;
     virtual bool renderCacheWasRecreated() const = 0;
     virtual void releaseRenderCache() = 0;

--- a/core/runtime/runtime_lifecycle.h
+++ b/core/runtime/runtime_lifecycle.h
@@ -136,6 +136,10 @@ inline void Runtime::requestFullPaint() {
     paintRequested_ = true;
 }
 
+inline void Runtime::setDirectRender(bool enabled) {
+    directRender_ = enabled;
+}
+
 inline void Runtime::render(int windowWidth, int windowHeight, float dpiScale, const Color& clearColor) {
     core::render::RenderBackend* renderBackend = core::render::activeRenderBackend();
     if (renderBackend == nullptr) {
@@ -156,7 +160,7 @@ inline void Runtime::render(int windowWidth, int windowHeight, float dpiScale, c
         return;
     }
 
-    if (!renderBackend->ensureRenderCache(windowWidth, windowHeight)) {
+    if (directRender_ || !renderBackend->ensureRenderCache(windowWidth, windowHeight)) {
         ++stats.clearCalls;
         renderBackend->clear(clearColor);
         ++stats.renderDirectPasses;

--- a/include/eui/detail/dsl_app_impl.h
+++ b/include/eui/detail/dsl_app_impl.h
@@ -212,6 +212,10 @@ void requestFullPaint() {
     core::platform::requestUiUpdate();
 }
 
+void setDirectRender(bool enabled) {
+    dslRuntime().setDirectRender(enabled);
+}
+
 } // namespace detail
 
 bool initialize(core::window::Handle window) {


### PR DESCRIPTION
问题

在 Windows 上拖动窗口的 resize 边框时，画面不会实时刷新，只有松开鼠标后才会更新到最终布局。

根因

Windows 处理 resize 拖拽时，会在 DefWindowProc（WM_SYSCOMMAND/SC_SIZE）内部运行一个模态循环。这个循环只派发消息、从不把控制权还给应用主循环，因此：

- glfwPollEvents() / glfwWaitEvents() 一直被卡住；
- 主循环的渲染逻辑要等鼠标松开、模态循环结束才会继续；
- 结果是拖拽过程中画面停留在旧内容（或被 DWM 拉伸的预览），松开才"跳"到正确布局。

修复方案（3 个 commit）

1. c18f703 fix(win32): repaint the main window live while resizing

对主窗口做一次 Windows 窗口子类化（与项目里 IME 桥的做法一致），拦截 WM_SIZING——模态循环在拖拽期间会持续派发此消息。收到消息时直接渲染一帧：

- 复用 MainWindowRuntime::updateAndRender，在当前窗口尺寸下更新布局并渲染；
- inputEnabled = false：把指针事件中性化，避免把边框拖拽误判成 UI 拖拽；
- 用既有帧时钟（nextFrameTime）节流到刷新率；
- 与 IME 的子类链正确衔接（后装先卸，WM_EXITSIZEMOVE 前卸载），Windows-only，仅作用于主窗口。

2. 3ee1736 perf(win32): render directly to the framebuffer while resizing

拖拽时整窗每帧都是脏的，保留渲染缓存（retained cache）没有意义——它只适合局部脏矩形增量重绘，此时纯属浪费 GPU 内存。

- 新增 Runtime::setDirectRender(bool) 与 app::detail::setDirectRender，让 Runtime::render 直接渲染到默认帧缓冲、跳过缓存（复用已有的 renderDirect 路径）；
- 拖拽 hook 在渲染期间开启、渲染后关闭；
- 避免缓存纹理在几十个中间尺寸上反复重建，降低峰值与私有内存（实测私有内存从 ~320MB 降到 ~90MB）。

3. b7c535b perf(win32): flush GPU work when a resize drag ends

拖拽中每次呈现都会按当前尺寸重建窗口 back-buffer，GL 驱动会把释放掉的缓冲暂存在内存池里；对完全空闲（无动画）的窗口，驱动惰性回收，内存可能残留较久。

- 新增 RenderBackend::flush()（OpenGL 实现 glFinish），在 WM_EXITSIZEMOVE 时调用；
- 尽力让驱动释放暂存缓冲（实测：慢速拖拽后内存可回落到 ~60-75MB）。

验证数据

- 实时刷新：埋点日志确认拖拽期间以当前尺寸连续渲染（如平滑拖拽 1.4s 内渲染约 50 帧，尺寸从 800×600 递增到 1241×1041），松开后主循环恢复正常。
- 渲染正确性：截图中拖拽中内容按当前窗口尺寸正确重排（与松开后一致）。
- 内存：快速拖拽（~1600px/s）有瞬时峰值（任何实时渲染的软件都有）；松开后回落速度取决于 GL 驱动。

已知限制（重要）

拖拽产生的 back-buffer 内存池由 Windows GL 驱动管理，应用层无法可靠强制提前释放：

- 实测了 glFinish、上下文 detach/reattach、连续 present、连续渲染等方案，均不能稳定强制驱动提前回收；
- 对完全静止的窗口，驱动按自身定时器释放（约 10 秒）；对持续渲染的应用（有动画/交互），内存池被复用，回落正常；
- 这是 GL 驱动的固有行为，不属于框架 bug。

后续建议（供作者参考）

如需兼顾"实时刷新流畅度"与"静止窗口内存"，可在框架层提供一个拖拽渲染策略选项，例如：

- 拖拽中渲染的尺寸步长（越大越省内存、越粗粒度）；
- 或拖拽渲染的帧率上限。

让使用者按需权衡，而不是框架替所有人做决定。

测试方法

构建后在 Windows 上运行任意示例（推荐 gallery 或一个简单窗口）：

1. 拖拽窗口边框，确认内容在拖拽过程中实时更新（不再等松开）；
2. 快速拖拽观察内存峰值（瞬时），松开后观察回落；
3. 用任务管理器或进程采样确认回落。