### PR TITLE
Feat/tab focus traversal

### DIFF
--- a/core/app/sdl2_app_main.cpp
+++ b/core/app/sdl2_app_main.cpp
@@ -171,6 +171,7 @@ bool mapKey(SDL_Keycode key, core::InputKey& mapped) {
     case SDLK_DOWN: mapped = core::InputKey::Down; return true;
     case SDLK_HOME: mapped = core::InputKey::Home; return true;
     case SDLK_END: mapped = core::InputKey::End; return true;
+    case SDLK_TAB: mapped = core::InputKey::Tab; return true;
     case SDLK_ESCAPE: mapped = core::InputKey::Escape; return true;
     case SDLK_a: mapped = core::InputKey::A; return true;
     case SDLK_c: mapped = core::InputKey::C; return true;

--- a/core/dsl_focus.h
+++ b/core/dsl_focus.h
@@ -1,0 +1,58 @@
+#pragma once
+
+#include "core/dsl.h"
+
+#include <algorithm>
+#include <string>
+#include <vector>
+
+namespace core::dsl {
+
+// Collect focusable element ids in z-order (back-to-front, stable by declaration
+// order when zIndex ties). Mirrors the order used by hit-testing and
+// Runtime::forEachElement. Skips elements inside disabled subtrees, matching
+// Runtime::findElementDisabledState semantics without a second tree walk.
+inline void collectFocusableIds(const Element& element,
+                                bool ancestorDisabled,
+                                std::vector<std::string>& out) {
+    const bool disabledTree = ancestorDisabled || element.disabled;
+    if (element.focusable && !disabledTree) {
+        out.push_back(element.id);
+    }
+    for (const Element* child : element.orderedChildren) {
+        collectFocusableIds(*child, disabledTree, out);
+    }
+}
+
+inline std::vector<std::string> collectOrderedFocusableIds(const Ui& ui) {
+    std::vector<std::string> ids;
+    for (const Element* root : ui.orderedRoots()) {
+        collectFocusableIds(*root, false, ids);
+    }
+    return ids;
+}
+
+// Next traversal target given the ordered focusable list, the current focus id
+// (possibly stale/disabled) and the direction. Empty current -> first/last;
+// current not in list (disabled or removed) -> first/last; wrap around at ends.
+inline std::string nextFocusTarget(const std::vector<std::string>& orderedIds,
+                                   const std::string& currentId,
+                                   bool reverse) {
+    if (orderedIds.empty()) {
+        return {};
+    }
+    if (currentId.empty()) {
+        return reverse ? orderedIds.back() : orderedIds.front();
+    }
+    const auto it = std::find(orderedIds.begin(), orderedIds.end(), currentId);
+    if (it == orderedIds.end()) {
+        return reverse ? orderedIds.back() : orderedIds.front();
+    }
+    const std::size_t index = static_cast<std::size_t>(it - orderedIds.begin());
+    if (reverse) {
+        return orderedIds[index == 0 ? orderedIds.size() - 1 : index - 1];
+    }
+    return orderedIds[(index + 1) % orderedIds.size()];
+}
+
+} // namespace core::dsl

--- a/core/dsl_runtime.h
+++ b/core/dsl_runtime.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "core/dsl.h"
+#include "core/dsl_focus.h"
 #include "core/platform/platform.h"
 #include "core/input/input_state.h"
 #include "core/render/image.h"
@@ -38,6 +39,13 @@ public:
     void compose(const std::string& pageId, float logicalWidth, float logicalHeight, ComposeFn&& composeFn);
 
     bool update(core::window::Handle window, float deltaSeconds, float pointerScale, float dpiScale, bool inputEnabled = true);
+
+    // Move keyboard focus to the next (or previous, when reverse) focusable
+    // element, wrapping around the ends. No-op when there is nothing focusable.
+    void traverseFocus(bool reverse = false);
+
+    // Currently focused element id (resolved, empty when nothing is focused).
+    std::string focusedId() const;
 
     bool isAnimating() const;
 
@@ -161,6 +169,10 @@ private:
                                  std::string& targetId) const;
 
     void setFocusedId(const std::string& id);
+
+    // Consume Tab/Shift+Tab for focus traversal. Returns true when the event
+    // was handled (caller should not forward it to updateTextInput).
+    bool handleFocusTraversal(const KeyboardEvent& event);
 
     void updateScroll(const ScrollEvent& event, const std::string& targetId);
 

--- a/core/input/input_types.h
+++ b/core/input/input_types.h
@@ -42,7 +42,8 @@ enum class InputKey {
     V,
     X,
     Y,
-    Z
+    Z,
+    Tab
 };
 
 enum class KeyAction {

--- a/core/runtime/runtime_input.h
+++ b/core/runtime/runtime_input.h
@@ -252,6 +252,27 @@ inline void Runtime::setFocusedId(const std::string& id) {
     paintRequested_ = true;
 }
 
+inline void Runtime::traverseFocus(bool reverse) {
+    const std::vector<std::string> ids = collectOrderedFocusableIds(ui_);
+    if (ids.empty()) {
+        return;
+    }
+    setFocusedId(nextFocusTarget(ids, focusedId_, reverse));
+}
+
+inline bool Runtime::handleFocusTraversal(const KeyboardEvent& event) {
+    const KeyEvent* tab = event.findKey(InputKey::Tab);
+    if (tab == nullptr || tab->modifiers.shortcut) {
+        return false;
+    }
+    traverseFocus(tab->modifiers.shift);
+    return true;
+}
+
+inline std::string Runtime::focusedId() const {
+    return focusedId_;
+}
+
 inline void Runtime::updateScroll(const ScrollEvent& event, const std::string& targetId) {
     const Element* element = targetId.empty() ? nullptr : ui_.find(targetId);
     const std::string activeScrollStateId = element != nullptr && !element->disabled

--- a/core/runtime/runtime_lifecycle.h
+++ b/core/runtime/runtime_lifecycle.h
@@ -99,7 +99,7 @@ inline bool Runtime::update(core::window::Handle window, float deltaSeconds, flo
     updateElementTree(event, deltaSeconds, dpiScale, hoverTargetId);
     updateDependentVisualDirtyRegions(dpiScale);
 
-    if (keyboardEvent.hasInput()) {
+    if (keyboardEvent.hasInput() && !handleFocusTraversal(keyboardEvent)) {
         updateTextInput(keyboardEvent);
     }
     instances_.releaseUnseenTimers();

--- a/core/window/window_input_backend.cpp
+++ b/core/window/window_input_backend.cpp
@@ -144,6 +144,7 @@ void installInputCallbacks(Handle window) {
         case GLFW_KEY_DOWN: queueKey(core::InputKey::Down); break;
         case GLFW_KEY_HOME: queueKey(core::InputKey::Home); break;
         case GLFW_KEY_END: queueKey(core::InputKey::End); break;
+        case GLFW_KEY_TAB: queueKey(core::InputKey::Tab); break;
         case GLFW_KEY_ESCAPE: queueKey(core::InputKey::Escape); break;
         case GLFW_KEY_A: queueKey(core::InputKey::A); break;
         case GLFW_KEY_C: queueKey(core::InputKey::C); break;

--- a/docs/DSL.md
+++ b/docs/DSL.md
@@ -628,7 +628,8 @@ components::button(ui, "save")
 
 - 已有基础 z-index、矩形 clip 和 Runtime scroll state；复杂圆角 clip、嵌套滚动区域的事件冒泡还没做。
 - `components::scrollView` 是推荐的普通滚动区域；超长固定行高数据使用 `components::virtualList`，避免一次性 compose 全部行。底层 `components::scroll` 只负责滚动条，需要和内容容器绑定同一个 Runtime scroll state。
-- 已有基础键盘 focus / text input / 选择 / 剪贴板 / 撤销 / 重做 / IME 预编辑组合串和系统候选窗口定位。
+- 已有基础键盘 focus / Tab 焦点遍历（按绘制序在 focusable 元素间循环，Shift+Tab 反向）/ text input / 选择 / 剪贴板 / 撤销 / 重做 / IME 预编辑组合串和系统候选窗口定位。
+- Tab 遍历集合 = `.focusable()` / `.onTextInput()` / `.onFocusChanged()` 的元素；`components::button` 默认只设 `interactive` 不设 `focusable`，不参与 Tab，需要时显式 `.focusable()`。第一版不跳过滚出视口/被裁剪的元素。
 - 还没有事件冒泡。
 - 已有 click / press / release / pointer move / hover / context menu / text input / scroll / drag 回调；局部坐标或组合手势开发使用 `components::mouseArea`，简单点击直接绑定可视图元。
 - 默认 hit-test 按布局矩形计算；开启 `.transformedHitTest()` 后会按元素当前 transform 和父容器继承矩阵反投影命中。

--- a/docs/事件.md
+++ b/docs/事件.md
@@ -200,11 +200,12 @@ ui.stack(id)
 1. `readPointerEvent(window, pointerScale)` 读取 pointer。
 2. `consumeInputEvents()` 消费 GLFW char / key / scroll callback 收集到的输入。
 3. 鼠标按下时按 topmost focus hit-test 更新 focused element；上层 interactive blocker 会阻断到底层 input 的焦点穿透。
-4. 从 DSL 树中找出最上层命中的 interactive 元素；如果已有 active 捕获元素，则优先使用捕获元素。
-5. 更新每个 interactive 元素的 `InteractionState`，但只有 topmost target 会进入 hover / press / click。
-6. 派发 `onHover` / `onMove` / `onPress` / `onRelease` / `onClick` / `onContextMenu` / `onDrag` / `onScroll` / `onTextInput`，并在需要时设置 `composeRequested()`。
-7. 根据 hover 设置 GLFW 手型 cursor。
-8. Rect 根据交互状态推进 hover / press 缓动并标记 dirty rect。
+4. Tab / Shift+Tab 在派发键盘事件**之前**先做焦点遍历并消费该按键（Shift 反向，focusable 元素间循环）；被消费时不进入 `onTextInput`。
+5. 从 DSL 树中找出最上层命中的 interactive 元素；如果已有 active 捕获元素，则优先使用捕获元素。
+6. 更新每个 interactive 元素的 `InteractionState`，但只有 topmost target 会进入 hover / press / click。
+7. 派发 `onHover` / `onMove` / `onPress` / `onRelease` / `onClick` / `onContextMenu` / `onDrag` / `onScroll` / `onTextInput`，并在需要时设置 `composeRequested()`。
+8. 根据 hover 设置 GLFW 手型 cursor。
+9. Rect 根据交互状态推进 hover / press 缓动并标记 dirty rect。
 
 ## 外部链接
 
@@ -245,7 +246,8 @@ eui::platform::openUrl("https://github.com/sudoevolve/EUI-NEO");
 
 ## 当前限制
 
-- 已有基础键盘文本输入、focus manager、选择、剪贴板、撤销、重做、IME 预编辑组合串和系统 IME 候选窗口定位；自绘 IME 候选 UI 还没做。
+- 已有基础键盘文本输入、focus manager、Tab 焦点遍历、选择、剪贴板、撤销、重做、IME 预编辑组合串和系统 IME 候选窗口定位；自绘 IME 候选 UI 还没做。
+- Tab 焦点遍历按绘制序（zIndex 稳定排序）在 focusable 元素间循环，Shift+Tab 反向；第一版**不跳过**滚出视口/被裁剪的元素。后端只建模 ctrl / shift 修饰键，Alt+Tab 无法与普通 Tab 区分。
 - 没有事件冒泡和捕获阶段。
 - 原生多点触摸还没做；触摸屏如果由系统映射成鼠标事件，可以走现有 pointer / `mouseArea`。
 - 默认 hit-test 按布局矩形计算；开启 `.transformedHitTest()` 后会按元素当前 transform 和父容器继承矩阵反投影命中。

--- a/tests/fixtures/focus_traversal_viewer.cpp
+++ b/tests/fixtures/focus_traversal_viewer.cpp
@@ -1,0 +1,123 @@
+#include "eui_neo.h"
+
+#include <string>
+
+namespace app {
+namespace {
+
+std::string& nameValue() {
+    static std::string value;
+    return value;
+}
+
+std::string& emailValue() {
+    static std::string value;
+    return value;
+}
+
+void labeledFocusableRect(eui::Ui& ui,
+                          const std::string& id,
+                          const std::string& label,
+                          float x,
+                          float y,
+                          float width,
+                          float height) {
+    const bool focused = ui.isFocused(id);
+    ui.rect(id)
+        .position(x, y)
+        .size(width, height)
+        .color(focused ? eui::Color{0.24f, 0.42f, 0.62f, 1.0f}
+                       : eui::Color{0.18f, 0.22f, 0.30f, 1.0f})
+        .border(focused ? 2.0f : 1.0f,
+                focused ? eui::Color{0.34f, 0.72f, 1.0f, 1.0f}
+                        : eui::Color{0.32f, 0.38f, 0.48f, 1.0f})
+        .focusable()
+        .onClick([] {})
+        .build();
+    ui.text(id + ".label")
+        .position(x, y)
+        .size(width, height)
+        .text(label)
+        .fontSize(14.0f)
+        .lineHeight(18.0f)
+        .color({0.90f, 0.94f, 1.0f, 1.0f})
+        .verticalAlign(eui::VerticalAlign::Center)
+        .build();
+}
+
+} // namespace
+
+const DslAppConfig& dslAppConfig() {
+    static const DslAppConfig config = DslAppConfig{}
+        .title("Focus Traversal Viewer")
+        .pageId("focus_traversal_viewer")
+        .clearColor({0.14f, 0.16f, 0.19f, 1.0f})
+        .windowSize(720, 560)
+        .showDebugStatsInTitle(false)
+        .fps(0.0)
+        .iconPath("");
+    return config;
+}
+
+void compose(eui::Ui& ui, const eui::Screen& screen) {
+    const float x = 60.0f;
+    const float width = screen.width - 120.0f;
+    const float inputHeight = 42.0f;
+    const float gap = 16.0f;
+
+    ui.text("hint")
+        .position(x, 24.0f)
+        .size(width, 44.0f)
+        .text("Tab / Shift+Tab 遍历焦点，循环；禁用元素被跳过；components::button 默认不可 Tab 聚焦，"
+              "下面的按钮是显式 .focusable() 的裸 rect")
+        .fontSize(14.0f)
+        .lineHeight(20.0f)
+        .color({0.78f, 0.83f, 0.92f, 1.0f})
+        .wrap()
+        .build();
+
+    ui.stack("field.name.wrap")
+        .position(x, 92.0f)
+        .size(width, inputHeight)
+        .content([&] {
+            components::input(ui, "field.name")
+                .size(width, inputHeight)
+                .value(nameValue())
+                .placeholder("Name（焦点边框由 input 组件自绘）")
+                .onChange([](const std::string& value) { nameValue() = value; })
+                .build();
+        })
+        .build();
+
+    ui.stack("field.email.wrap")
+        .position(x, 92.0f + (inputHeight + gap))
+        .size(width, inputHeight)
+        .content([&] {
+            components::input(ui, "field.email")
+                .size(width, inputHeight)
+                .value(emailValue())
+                .placeholder("Email")
+                .onChange([](const std::string& value) { emailValue() = value; })
+                .build();
+        })
+        .build();
+
+    // Disabled subtree: the wrapped input renders but is skipped by Tab.
+    ui.stack("field.disabled.wrap")
+        .position(x, 92.0f + 2.0f * (inputHeight + gap))
+        .size(width, inputHeight)
+        .disabled(true)
+        .content([&] {
+            components::input(ui, "field.disabled")
+                .size(width, inputHeight)
+                .value(std::string("Disabled field（Tab 跳过）"))
+                .build();
+        })
+        .build();
+
+    const float rowY = 92.0f + 3.0f * (inputHeight + gap);
+    labeledFocusableRect(ui, "field.button", "Focusable rect（显式 .focusable()）", x, rowY, 260.0f, 40.0f);
+    labeledFocusableRect(ui, "field.rect", "另一个 focusable", x + 280.0f, rowY, 220.0f, 40.0f);
+}
+
+} // namespace app

--- a/tests/probes/window_only_probe.cpp
+++ b/tests/probes/window_only_probe.cpp
@@ -103,12 +103,18 @@ bool verifySdlWindowInput(core::window::Handle firstWindow,
                         {core::InputKey::Left,
                          core::KeyAction::Repeat,
                          {false, true}});
+    core::queueKeyInput(firstWindow,
+                        {core::InputKey::Tab,
+                         core::KeyAction::Press,
+                         {false, true}});
 
     auto input = core::consumeInputEvents(firstWindow);
     const core::KeyEvent* left = input.first.findKey(core::InputKey::Left);
+    const core::KeyEvent* tab = input.first.findKey(core::InputKey::Tab);
     const bool queued = input.first.text == "ok" &&
         input.first.compositionText == "ime" && input.first.composing &&
         left != nullptr && left->action == core::KeyAction::Repeat && left->modifiers.shift &&
+        tab != nullptr && tab->modifiers.shift && !tab->modifiers.shortcut &&
         input.second.x == 1.25 && input.second.y == -2.5;
 
     core::queuePointerButton(firstWindow, 31.0, 47.0, 0, false);

--- a/tests/unit/focus_traversal.cpp
+++ b/tests/unit/focus_traversal.cpp
@@ -1,0 +1,338 @@
+#include "core/dsl_focus.h"
+#include "core/dsl_runtime.h"
+
+#include <iostream>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace {
+
+std::string orderText(const std::vector<std::string>& ids) {
+    std::string text;
+    for (const std::string& id : ids) {
+        if (!text.empty()) {
+            text += " ";
+        }
+        text += id;
+    }
+    return text;
+}
+
+bool expectOrder(const char* label, const std::vector<std::string>& ids,
+                 const std::vector<std::string>& expected) {
+    if (ids == expected) {
+        return true;
+    }
+    std::cerr << label << ": got [" << orderText(ids) << "] expected ["
+              << orderText(expected) << "]\n";
+    return false;
+}
+
+// ---------- Pure helper tests (Ui + layout, no Runtime) ----------
+
+bool collectFlatOrder() {
+    core::dsl::Ui ui;
+    ui.begin("page");
+    ui.rect("a").size(10.0f, 10.0f).focusable().build();
+    ui.rect("b").size(10.0f, 10.0f).focusable().build();
+    ui.rect("c").size(10.0f, 10.0f).focusable().build();
+    ui.end();
+    ui.layout(800.0f, 600.0f);
+    return expectOrder("collectFlatOrder", core::dsl::collectOrderedFocusableIds(ui),
+                       {"page.a", "page.b", "page.c"});
+}
+
+bool collectHonorsZOrder() {
+    core::dsl::Ui ui;
+    ui.begin("page");
+    ui.rect("a").size(10.0f, 10.0f).focusable().zIndex(0).build();
+    ui.rect("b").size(10.0f, 10.0f).focusable().zIndex(2).build();
+    ui.rect("c").size(10.0f, 10.0f).focusable().zIndex(1).build();
+    ui.end();
+    ui.layout(800.0f, 600.0f);
+    return expectOrder("collectHonorsZOrder", core::dsl::collectOrderedFocusableIds(ui),
+                       {"page.a", "page.c", "page.b"});
+}
+
+bool collectSkipsDisabled() {
+    core::dsl::Ui ui;
+    ui.begin("page");
+    ui.rect("a").size(10.0f, 10.0f).focusable().build();
+    ui.rect("b").size(10.0f, 10.0f).focusable().disabled().build();
+    ui.rect("c").size(10.0f, 10.0f).focusable().build();
+    ui.end();
+    ui.layout(800.0f, 600.0f);
+    return expectOrder("collectSkipsDisabled", core::dsl::collectOrderedFocusableIds(ui),
+                       {"page.a", "page.c"});
+}
+
+bool collectSkipsDisabledTree() {
+    core::dsl::Ui ui;
+    ui.begin("page");
+    ui.stack("p").focusable().disabled().content([&] {
+        ui.rect("q").size(10.0f, 10.0f).focusable().build();
+    }).build();
+    ui.rect("r").size(10.0f, 10.0f).focusable().build();
+    ui.end();
+    ui.layout(800.0f, 600.0f);
+    return expectOrder("collectSkipsDisabledTree", core::dsl::collectOrderedFocusableIds(ui),
+                       {"page.r"});
+}
+
+bool collectSkipsInteractiveNotFocusable() {
+    core::dsl::Ui ui;
+    ui.begin("page");
+    ui.rect("k").size(10.0f, 10.0f).onClick([] {}).build();
+    ui.end();
+    ui.layout(800.0f, 600.0f);
+    return expectOrder("collectSkipsInteractiveNotFocusable",
+                       core::dsl::collectOrderedFocusableIds(ui), {});
+}
+
+bool collectPreOrder() {
+    core::dsl::Ui ui;
+    ui.begin("page");
+    ui.stack("p").focusable().content([&] {
+        ui.rect("q").size(10.0f, 10.0f).focusable().build();
+        ui.rect("r").size(10.0f, 10.0f).focusable().build();
+    }).build();
+    ui.end();
+    ui.layout(800.0f, 600.0f);
+    return expectOrder("collectPreOrder", core::dsl::collectOrderedFocusableIds(ui),
+                       {"page.p", "page.q", "page.r"});
+}
+
+bool nextTargetEmptyList() {
+    const std::vector<std::string> ids;
+    if (!core::dsl::nextFocusTarget(ids, {}, false).empty() ||
+        !core::dsl::nextFocusTarget(ids, "page.a", true).empty()) {
+        std::cerr << "nextTargetEmptyList: expected empty target\n";
+        return false;
+    }
+    return true;
+}
+
+bool nextTargetNoCurrent() {
+    const std::vector<std::string> ids = {"page.a", "page.b", "page.c"};
+    if (core::dsl::nextFocusTarget(ids, {}, false) != "page.a" ||
+        core::dsl::nextFocusTarget(ids, {}, true) != "page.c") {
+        std::cerr << "nextTargetNoCurrent: expected first/last\n";
+        return false;
+    }
+    return true;
+}
+
+bool nextTargetMid() {
+    const std::vector<std::string> ids = {"page.a", "page.b", "page.c"};
+    if (core::dsl::nextFocusTarget(ids, "page.a", false) != "page.b" ||
+        core::dsl::nextFocusTarget(ids, "page.c", true) != "page.b") {
+        std::cerr << "nextTargetMid: forward/backward from ends failed\n";
+        return false;
+    }
+    return true;
+}
+
+bool nextTargetWrap() {
+    const std::vector<std::string> ids = {"page.a", "page.b", "page.c"};
+    if (core::dsl::nextFocusTarget(ids, "page.c", false) != "page.a" ||
+        core::dsl::nextFocusTarget(ids, "page.a", true) != "page.c") {
+        std::cerr << "nextTargetWrap: wrap around failed\n";
+        return false;
+    }
+    return true;
+}
+
+bool nextTargetCurrentMissing() {
+    const std::vector<std::string> ids = {"page.a", "page.b", "page.c"};
+    if (core::dsl::nextFocusTarget(ids, "page.ghost", false) != "page.a" ||
+        core::dsl::nextFocusTarget(ids, "page.ghost", true) != "page.c") {
+        std::cerr << "nextTargetCurrentMissing: stale current fell back wrong\n";
+        return false;
+    }
+    return true;
+}
+
+bool nextTargetSingle() {
+    const std::vector<std::string> ids = {"page.only"};
+    if (core::dsl::nextFocusTarget(ids, "page.only", false) != "page.only" ||
+        core::dsl::nextFocusTarget(ids, "page.only", true) != "page.only") {
+        std::cerr << "nextTargetSingle: single element did not stay put\n";
+        return false;
+    }
+    return true;
+}
+
+// ---------- Runtime-level tests (compose + traverseFocus + focusedId) ----------
+
+void composeThreeFocusables(core::dsl::Runtime& runtime, bool disableB = false) {
+    runtime.compose("page", 800.0f, 600.0f, [&](core::dsl::Ui& ui, const core::dsl::Screen&) {
+        ui.rect("a").size(10.0f, 10.0f).focusable().build();
+        ui.rect("b").size(10.0f, 10.0f).focusable().disabled(disableB).build();
+        ui.rect("c").size(10.0f, 10.0f).focusable().build();
+    });
+}
+
+bool runtimeFirstTabFromNone() {
+    core::dsl::Runtime runtime;
+    composeThreeFocusables(runtime);
+    runtime.traverseFocus(false);
+    const bool ok = runtime.focusedId() == "page.a";
+    if (!ok) {
+        std::cerr << "runtimeFirstTabFromNone: got " << runtime.focusedId() << "\n";
+    }
+    runtime.shutdown(false);
+    return ok;
+}
+
+bool runtimeShiftTabFromNone() {
+    core::dsl::Runtime runtime;
+    composeThreeFocusables(runtime);
+    runtime.traverseFocus(true);
+    const bool ok = runtime.focusedId() == "page.c";
+    if (!ok) {
+        std::cerr << "runtimeShiftTabFromNone: got " << runtime.focusedId() << "\n";
+    }
+    runtime.shutdown(false);
+    return ok;
+}
+
+bool runtimeCyclesForwardAndWraps() {
+    core::dsl::Runtime runtime;
+    composeThreeFocusables(runtime);
+    runtime.traverseFocus(false);
+    runtime.traverseFocus(false);
+    runtime.traverseFocus(false);
+    runtime.traverseFocus(false);
+    const bool ok = runtime.focusedId() == "page.a";
+    if (!ok) {
+        std::cerr << "runtimeCyclesForwardAndWraps: got " << runtime.focusedId() << "\n";
+    }
+    runtime.shutdown(false);
+    return ok;
+}
+
+bool runtimeShiftTabWraps() {
+    core::dsl::Runtime runtime;
+    composeThreeFocusables(runtime);
+    runtime.traverseFocus(false); // -> a
+    runtime.traverseFocus(true);  // wraps back to c
+    const bool ok = runtime.focusedId() == "page.c";
+    if (!ok) {
+        std::cerr << "runtimeShiftTabWraps: got " << runtime.focusedId() << "\n";
+    }
+    runtime.shutdown(false);
+    return ok;
+}
+
+bool runtimeSkipsDisabled() {
+    core::dsl::Runtime runtime;
+    composeThreeFocusables(runtime, /*disableB=*/true);
+    runtime.traverseFocus(false); // a
+    runtime.traverseFocus(false); // skips disabled b -> c
+    const bool ok = runtime.focusedId() == "page.c";
+    if (!ok) {
+        std::cerr << "runtimeSkipsDisabled: got " << runtime.focusedId() << "\n";
+    }
+    runtime.shutdown(false);
+    return ok;
+}
+
+bool runtimeFiresOnFocusChanged() {
+    core::dsl::Runtime runtime;
+    std::vector<std::pair<std::string, bool>> events;
+    runtime.compose("page", 800.0f, 600.0f, [&](core::dsl::Ui& ui, const core::dsl::Screen&) {
+        ui.rect("a").size(10.0f, 10.0f)
+            .onFocusChanged([&](bool focused) { events.emplace_back("page.a", focused); })
+            .build();
+        ui.rect("b").size(10.0f, 10.0f)
+            .onFocusChanged([&](bool focused) { events.emplace_back("page.b", focused); })
+            .build();
+        ui.rect("c").size(10.0f, 10.0f).focusable().build();
+    });
+
+    runtime.traverseFocus(false); // a gains focus
+    runtime.traverseFocus(false); // a loses, b gains
+
+    const std::vector<std::pair<std::string, bool>> expected = {
+        {"page.a", true},
+        {"page.a", false},
+        {"page.b", true},
+    };
+    const bool ok = events == expected;
+    if (!ok) {
+        std::cerr << "runtimeFiresOnFocusChanged: got " << events.size()
+                  << " events, expected " << expected.size() << "\n";
+    }
+    runtime.shutdown(false);
+    return ok;
+}
+
+bool runtimeClearsFocusWhenDisabled() {
+    core::dsl::Runtime runtime;
+    composeThreeFocusables(runtime);
+    runtime.traverseFocus(false); // a
+    if (runtime.focusedId() != "page.a") {
+        runtime.shutdown(false);
+        std::cerr << "runtimeClearsFocusWhenDisabled: setup failed\n";
+        return false;
+    }
+
+    // Re-compose with "a" now disabled: compose clears focus on the stale id.
+    runtime.compose("page", 800.0f, 600.0f, [&](core::dsl::Ui& ui, const core::dsl::Screen&) {
+        ui.rect("a").size(10.0f, 10.0f).focusable().disabled().build();
+        ui.rect("b").size(10.0f, 10.0f).focusable().build();
+        ui.rect("c").size(10.0f, 10.0f).focusable().build();
+    });
+
+    const bool cleared = runtime.focusedId().empty();
+    runtime.traverseFocus(false); // -> b (a is disabled)
+    const bool ok = cleared && runtime.focusedId() == "page.b";
+    if (!ok) {
+        std::cerr << "runtimeClearsFocusWhenDisabled: cleared=" << cleared
+                  << " focused=" << runtime.focusedId() << "\n";
+    }
+    runtime.shutdown(false);
+    return ok;
+}
+
+bool runtimeEmptyTreeDoesNothing() {
+    core::dsl::Runtime runtime;
+    runtime.compose("page", 800.0f, 600.0f,
+                    [&](core::dsl::Ui&, const core::dsl::Screen&) {});
+    runtime.traverseFocus(false);
+    runtime.traverseFocus(true);
+    const bool ok = runtime.focusedId().empty();
+    if (!ok) {
+        std::cerr << "runtimeEmptyTreeDoesNothing: got " << runtime.focusedId() << "\n";
+    }
+    runtime.shutdown(false);
+    return ok;
+}
+
+} // namespace
+
+int main() {
+    bool ok = true;
+    ok = collectFlatOrder() && ok;
+    ok = collectHonorsZOrder() && ok;
+    ok = collectSkipsDisabled() && ok;
+    ok = collectSkipsDisabledTree() && ok;
+    ok = collectSkipsInteractiveNotFocusable() && ok;
+    ok = collectPreOrder() && ok;
+    ok = nextTargetEmptyList() && ok;
+    ok = nextTargetNoCurrent() && ok;
+    ok = nextTargetMid() && ok;
+    ok = nextTargetWrap() && ok;
+    ok = nextTargetCurrentMissing() && ok;
+    ok = nextTargetSingle() && ok;
+    ok = runtimeFirstTabFromNone() && ok;
+    ok = runtimeShiftTabFromNone() && ok;
+    ok = runtimeCyclesForwardAndWraps() && ok;
+    ok = runtimeShiftTabWraps() && ok;
+    ok = runtimeSkipsDisabled() && ok;
+    ok = runtimeFiresOnFocusChanged() && ok;
+    ok = runtimeClearsFocusWhenDisabled() && ok;
+    ok = runtimeEmptyTreeDoesNothing() && ok;
+    return ok ? 0 : 1;
+}


### PR DESCRIPTION
## 概要

此前 Tab 键在输入后端直接被丢弃（GLFW / SDL 的按键映射都没有 Tab），
键盘焦点只能靠鼠标点击驱动。本 PR 加入纯增量的 Tab / Shift+Tab 焦点遍历：

- Tab 前进、Shift+Tab 后退，在 focusable 元素间循环（wrap）。
- 遍历顺序 = 绘制 / 命中顺序：对元素树前序遍历，按 `zIndex` 升序稳定排序
  （同 zIndex 按声明序）——即用户视觉上感知到的堆叠顺序。
- 因为 Tab 之前是 no-op，没有任何既有行为被破坏。

## 变更

- `InputKey` 新增 `Tab`，两端后端补上映射（`GLFW_KEY_TAB`、`SDLK_TAB`）。
- 新增 `core/dsl_focus.h`：`collectOrderedFocusableIds`（前序收集 focusable
  元素、跳过 disabled 子树）与 `nextFocusTarget`（前进 / 后退 / 回绕决策）。
- `Runtime` 新增公开 `traverseFocus(bool reverse)`、`focusedId()`，私有
  `handleFocusTraversal(const KeyboardEvent&)`。
- `Runtime::update` 在 `updateTextInput` **之前**消费 Tab 键；被消费时不再
  转发给当前焦点输入框。

## 行为

- 遍历集合 = `.focusable()` / `.onTextInput()` / `.onFocusChanged()` 的元素，
  与鼠标 focus 命中的集合一致；跳过 disabled / 禁用子树。
- 无焦点时 Tab 聚焦第一个、Shift+Tab 聚焦最后一个。
- `components::button` 默认只设 `interactive`、不设 `focusable`，默认不参与
  Tab（需显式 `.focusable()`），保持既有默认行为不变。
- Ctrl / Cmd+Tab 不消费，行为不变。

## 测试与验证

## 测试与验证

- 新增 headless 单测 `tests/unit/focus_traversal.cpp`（20 个用例：顺序、
  zIndex、disabled 子树、回绕、`onFocusChanged`、禁用时清焦点）。
- `window_only_probe` 扩展：验证 Tab+Shift 携带方向进入输入队列。
- 新增 windowed fixture `tests/fixtures/focus_traversal_viewer.cpp` 供人工
  Tab / Shift+Tab 验证。
- 全量 Debug 构建通过；`ctest -L unit` 16/16、`ctest -L probe` 5/5 全部通过。

## 已知限制

- V1 不跳过滚出视口 / 被裁剪的元素。
- Alt+Tab 无法与普通 Tab 区分（后端只建模 ctrl / shift 修饰键）。
- SDL 后端 Ctrl+Tab 的 `\t` 文本加固未包含（可选后续）。
