### PR TITLE
fix(xmake): compile GLFW Wayland backend on Linux

### DIFF
--- a/xmake.lua
+++ b/xmake.lua
@@ -433,6 +433,46 @@ if window_backend == "glfw" then
             )
             add_defines("_GLFW_X11", "_DEFAULT_SOURCE")
             add_syslinks("X11", "Xrandr", "Xinerama", "Xi", "Xcursor", "Xext", "dl", "m", "rt", {public = true})
+            on_load(function (target)
+                import("lib.detect.find_tool")
+                import("package.manager.find_package")
+
+                local scanner = find_tool("wayland-scanner")
+                local wl_client = find_package("pkgconfig::wayland-client")
+                local xkb = find_package("pkgconfig::xkbcommon")
+
+                if scanner and wl_client and xkb then
+                    local gen_dir = path.join(target:autogendir(), "wayland_protocols")
+                    os.mkdir(gen_dir)
+                    local protocols = {
+                        "wayland", "viewporter", "xdg-shell", "idle-inhibit-unstable-v1",
+                        "pointer-constraints-unstable-v1", "relative-pointer-unstable-v1",
+                        "fractional-scale-v1", "xdg-activation-v1", "xdg-decoration-unstable-v1"
+                    }
+                    for _, proto in ipairs(protocols) do
+                        local xml = path.join(os.projectdir(), "3rd/glfw/deps/wayland", proto .. ".xml")
+                        local header = path.join(gen_dir, proto .. "-client-protocol.h")
+                        local code = path.join(gen_dir, proto .. "-client-protocol-code.h")
+                        if not os.exists(header) or os.mtime(xml) > os.mtime(header) then
+                            os.execv(scanner.program, {"client-header", xml, header})
+                        end
+                        if not os.exists(code) or os.mtime(xml) > os.mtime(code) then
+                            os.execv(scanner.program, {"private-code", xml, code})
+                        end
+                    end
+                    target:add("includedirs", gen_dir)
+                    target:add("defines", "_GLFW_WAYLAND")
+                    target:add("files",
+                        "3rd/glfw/src/wl_init.c",
+                        "3rd/glfw/src/wl_monitor.c",
+                        "3rd/glfw/src/wl_window.c",
+                        {sourcekind = "cc"}
+                    )
+                    if wl_client.includedirs then target:add("includedirs", wl_client.includedirs) end
+                    if xkb.includedirs then target:add("includedirs", xkb.includedirs) end
+                    target:add("syslinks", "wayland-client", "wayland-cursor", "wayland-egl", "xkbcommon", {public = true})
+                end
+            end)
         end
     target_end()
 end


### PR DESCRIPTION
### What
- Hook `wayland-scanner` protocol code generation and compile Wayland backend sources (`wl_init.c`, `wl_monitor.c`, `wl_window.c`) into `eui_glfw` on Linux.
- Maintain dual-backend support (`_GLFW_WAYLAND` + `_GLFW_X11`) with graceful fallback to X11-only if Wayland development packages are absent.

### Why
- The vendored GLFW xmake target previously only compiled X11 sources (`x11_*.c`) with `_GLFW_X11`, preventing applications from running natively under Wayland compositors and forcing them into XWayland.

### How
- In `eui_glfw`'s `on_load`, probe for `wayland-scanner`, `wayland-client`, and `xkbcommon`.
- If found, generate protocol headers and code from `3rd/glfw/deps/wayland/*.xml` into `target:autogendir()`, add `_GLFW_WAYLAND`, append Wayland source files, and link client libraries.
- If not found, retain the default X11-only build.

### Rationale & Reference
- **Upstream GLFW 3.4 CMake parity**: Matches `3rd/glfw/src/CMakeLists.txt` (lines 66–107), which generates protocol headers from `3rd/glfw/deps/wayland/*.xml` using `wayland-scanner` (`client-header` and `private-code`) and enables both Wayland and X11 by default.
- **Self-contained in tree**: The 9 protocol XML files are already bundled in `3rd/glfw/deps/wayland/`.
- **Runtime multi-backend selection**: GLFW 3.4 dynamically detects `WAYLAND_DISPLAY` at `glfwInit()` and prefers native Wayland while dynamically loading client libraries via `dlopen`.
- **Zero regression on non-Wayland setups**: When `wayland-scanner` or Wayland packages are missing, the target silently falls back to pure X11 without failing configuration or compilation.